### PR TITLE
Fix GetSpacyVersion logic for minor patches > 0

### DIFF
--- a/Catalyst.Spacy/src/Spacy.cs
+++ b/Catalyst.Spacy/src/Spacy.cs
@@ -121,8 +121,8 @@ namespace Catalyst
                 }
                 else
                 {
-                    var fixedVersion = CompatibilityData.Keys
-                                         .Where(k => k.StartsWith(version))
+                    var fixedVersion = CompatibilityData["spacy"].Keys
+                                         .Where(version.StartsWith)
                                          .Select((k) => (key: k, version: System.Version.TryParse(k, out var v) ? v : null))
                                          .Where(k => k.version is object)
                                          .OrderByDescending(k => k.version)


### PR DESCRIPTION
#84 I tried to run Catalyst.Spacy but it looks like the logic for "fixedVersion" is slightly incorrect causing issues.

