### PR TITLE
Fix abbr detection in the end of text

### DIFF
--- a/Catalyst/src/Models/Special/AbbreviationCapturer.cs
+++ b/Catalyst/src/Models/Special/AbbreviationCapturer.cs
@@ -73,7 +73,7 @@ namespace Catalyst.Models
                 var pooledTokens = span.ToTokenSpanPolled(out var actualLength);
                 var tokens = pooledTokens.AsSpan(0, actualLength);
 
-                int N = tokens.Length - 3;
+                int N = tokens.Length - 2;
 
                 for (int i = 1; i < N; i++)
                 {

--- a/tests/Catalyst.Tests/PipelineTests.cs
+++ b/tests/Catalyst.Tests/PipelineTests.cs
@@ -59,6 +59,7 @@ namespace Catalyst.Tests
 
         [Theory]
         [InlineData("this is an abbreviation test As Soon As Possible (ASAP) I hope this abbreviation was found")]
+        [InlineData("this is an abbreviation test As Soon As Possible (ASAP)")]
         public async Task Abbreviations(string text)
         {
             English.Register();


### PR DESCRIPTION
If abbreviation defined as last word at the end of text, then abbreviation is not detected.