### PR TITLE
LinkedSpotter: opt-in graph-validated probabilistic membership mode

### DIFF
--- a/Catalyst/src/Models/EntityRecognition/CompactHashStructures.cs
+++ b/Catalyst/src/Models/EntityRecognition/CompactHashStructures.cs
@@ -87,6 +87,14 @@ namespace Catalyst.Models
                 ? new MphFingerprintMap64(map)
                 : (ICompactHashMap64)new MphHashMap64(map);
         }
+
+        // Probabilistic membership set (16-bit fingerprint, ~2^-16 false positives, no false negatives).
+        // Used when the caller can validate captures against an authoritative source (e.g. the graph), so a
+        // tiny false-positive rate is acceptable in exchange for ~3.5 B/key and dropping the stored values.
+        public static ICompactHashSet64 BuildProbabilisticSet(ICollection<ulong> keys)
+        {
+            return new MphFingerprint16Set64(keys);
+        }
     }
 
     /// <summary>

--- a/Catalyst/src/Models/EntityRecognition/LinkedSpotter.cs
+++ b/Catalyst/src/Models/EntityRecognition/LinkedSpotter.cs
@@ -23,6 +23,14 @@ namespace Catalyst.Models
         public bool IgnoreCase { get; set; }
     }
 
+    /// <summary>
+    /// Resolves the captured surface text to the authoritative graph node UID, or returns a null
+    /// <see cref="UID128"/> to reject the capture. Supplying one to a <see cref="LinkedSpotter"/> switches its
+    /// frozen tables to a low-memory probabilistic (false-positive, never false-negative) representation: the
+    /// resolver both filters the (rare) false positives and provides the UID, so the stored UIDs are dropped.
+    /// </summary>
+    public delegate UID128 CaptureResolver(ReadOnlySpan<char> matchedText);
+
     public class LinkedSpotter : StorableObjectV2<LinkedSpotter, LinkedSpotterModel>, IEntityRecognizer, IProcess, IHasSimpleSpecialCases, ICanOptimizeMemory
     {
         public string CaptureTag => Data.CaptureTag;
@@ -32,8 +40,18 @@ namespace Catalyst.Models
         public const string Separator = "_";
 
         private ICompactHashMap64   _frozenHashes;
+        private ICompactHashSet64   _frozenHashesSet; // membership-only mode (resolver supplies the UID)
         private ICompactHashSet64[] _frozenMultiGram;
         private bool                _frozen;
+        private bool                _membershipOnly;
+        private CaptureResolver     _captureResolver;
+
+        /// <summary>
+        /// Sets the graph-backed capture resolver. Must be called before the model is frozen
+        /// (<see cref="OptimizeMemory"/> / load-time compaction); once set, freezing uses the probabilistic
+        /// membership tables. The model then becomes read-only (cannot be mutated or re-stored losslessly).
+        /// </summary>
+        public void SetCaptureResolver(CaptureResolver resolver) => _captureResolver = resolver;
 
         /// <summary>True once the model's hash tables have been compacted into their read-only in-memory form.</summary>
         public bool IsMemoryOptimized => _frozen;
@@ -44,7 +62,7 @@ namespace Catalyst.Models
             get
             {
                 if (!_frozen) { return 0; }
-                long mem = _frozenHashes?.EstimatedBytes ?? 0;
+                long mem = _membershipOnly ? (_frozenHashesSet?.EstimatedBytes ?? 0) : (_frozenHashes?.EstimatedBytes ?? 0);
                 if (_frozenMultiGram is object)
                 {
                     foreach (var s in _frozenMultiGram) { mem += s.EstimatedBytes; }
@@ -96,13 +114,31 @@ namespace Catalyst.Models
         {
             if (_frozen || Data is null || Data.Hashes is null) { return; }
 
-            _frozenHashes = CompactHash.BuildMap(Data.Hashes);
-
             var multi = Data.MultiGramHashes;
-            _frozenMultiGram = new ICompactHashSet64[multi?.Count ?? 0];
-            for (int i = 0; i < _frozenMultiGram.Length; i++)
+
+            if (_captureResolver is object)
             {
-                _frozenMultiGram[i] = CompactHash.BuildSet(multi[i]);
+                // Membership-only: the resolver supplies the UID and rejects false positives, so we keep only a
+                // probabilistic membership filter over the keys and drop the (16-byte) UID values entirely.
+                _frozenHashesSet = CompactHash.BuildProbabilisticSet(Data.Hashes.Keys);
+
+                _frozenMultiGram = new ICompactHashSet64[multi?.Count ?? 0];
+                for (int i = 0; i < _frozenMultiGram.Length; i++)
+                {
+                    _frozenMultiGram[i] = CompactHash.BuildProbabilisticSet(multi[i]);
+                }
+
+                _membershipOnly = true;
+            }
+            else
+            {
+                _frozenHashes = CompactHash.BuildMap(Data.Hashes);
+
+                _frozenMultiGram = new ICompactHashSet64[multi?.Count ?? 0];
+                for (int i = 0; i < _frozenMultiGram.Length; i++)
+                {
+                    _frozenMultiGram[i] = CompactHash.BuildSet(multi[i]);
+                }
             }
 
             _frozen              = true;
@@ -115,6 +151,11 @@ namespace Catalyst.Models
         private void Unfreeze()
         {
             if (!_frozen) { return; }
+
+            if (_membershipOnly)
+            {
+                throw new InvalidOperationException("This LinkedSpotter was frozen with a graph-backed capture resolver (probabilistic membership) and cannot be modified or re-stored losslessly. Rebuild it without a capture resolver to modify it.");
+            }
 
             if (_frozenHashes is object && !_frozenHashes.CanEnumerateKeys)
             {
@@ -241,7 +282,9 @@ namespace Catalyst.Models
         public void ClearModel()
         {
             _frozen          = false;
+            _membershipOnly  = false;
             _frozenHashes    = null;
+            _frozenHashesSet = null;
             _frozenMultiGram = null;
 
             Data.Hashes                 = new Dictionary<ulong, UID128>();
@@ -256,6 +299,14 @@ namespace Catalyst.Models
 
             int N = tokens.Length;
             bool hasMultiGram = HasMultiGram();
+
+            if (_membershipOnly)
+            {
+                bool found = RecognizeEntitiesMembership(tokens, N, hasMultiGram, stopOnFirstFound);
+                ArrayPool<Token>.Shared.Return(pooledTokens);
+                return found;
+            }
+
             bool foundAny = false;
             for (int i = 0; i < N; i++)
             {
@@ -322,6 +373,108 @@ namespace Catalyst.Models
             ArrayPool<Token>.Shared.Return(pooledTokens);
 
             return foundAny;
+        }
+
+        // Membership-only recognition: the frozen tables only answer "could this be a known key" (with a tiny
+        // false-positive rate and no false negatives); the capture resolver validates each candidate against the
+        // graph and supplies the authoritative UID, dropping false positives. Mirrors the longest-match semantics
+        // of the exact path, resolving at each combined-hash hit and keeping the longest VALIDATED match.
+        private bool RecognizeEntitiesMembership(System.Span<Token> tokens, int N, bool hasMultiGram, bool stopOnFirstFound)
+        {
+            bool foundAny = false;
+            for (int i = 0; i < N; i++)
+            {
+                int i0 = i;
+                var tk = tokens[i0];
+                var tokenHash = Data.IgnoreCase ? IgnoreCaseHash64(tk.ValueAsSpan) : Hash64(tk.ValueAsSpan);
+
+                if (hasMultiGram && MultiGramContains(0, tokenHash))
+                {
+                    int    window    = Math.Min(N - i0, MultiGramCount());
+                    ulong  hash      = tokenHash;
+                    int    i_final   = i0;
+                    UID128 uid_final = default;
+
+                    for (int n = 1; n < window; n++)
+                    {
+                        var next     = tokens[n + i0];
+                        var nextHash = Data.IgnoreCase ? IgnoreCaseHash64(next.ValueAsSpan) : Hash64(next.ValueAsSpan);
+
+                        if (MultiGramContains(n, nextHash))
+                        {
+                            hash = HashCombine64(hash, nextHash);
+                            if (_frozenHashesSet.Contains(hash))
+                            {
+                                var uid = ResolveMatch(tokens, i0, i0 + n);
+                                if (uid.IsNotNull())
+                                {
+                                    i_final   = i0 + n;
+                                    uid_final = uid;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    if (i_final > i0)
+                    {
+                        foundAny = true;
+                        if (stopOnFirstFound) { return foundAny; }
+                        tk.AddEntityType(new EntityType(CaptureTag, EntityTag.Begin, uid_final));
+                        tokens[i_final].AddEntityType(new EntityType(CaptureTag, EntityTag.End, uid_final));
+
+                        for (int m = i0 + 1; m < i_final; m++)
+                        {
+                            tokens[m].AddEntityType(new EntityType(CaptureTag, EntityTag.Inside, uid_final));
+                        }
+                    }
+
+                    i = i_final;
+                }
+
+                if (_frozenHashesSet.Contains(tokenHash))
+                {
+                    var uid = ResolveMatch(tokens, i0, i0);
+                    if (uid.IsNotNull())
+                    {
+                        foundAny = true;
+                        if (stopOnFirstFound) { return foundAny; }
+                        tk.AddEntityType(new EntityType(CaptureTag, EntityTag.Single, uid));
+                    }
+                }
+            }
+
+            return foundAny;
+        }
+
+        // Rebuilds the matched surface (single token, or words joined by a single space - matching how AddEntry
+        // keys multi-word entries) and asks the resolver for the authoritative UID (null = reject).
+        private UID128 ResolveMatch(System.Span<Token> tokens, int start, int end)
+        {
+            if (start == end)
+            {
+                return _captureResolver(tokens[start].ValueAsSpan);
+            }
+
+            int length = end - start; // single-space separators between words
+            for (int k = start; k <= end; k++) { length += tokens[k].ValueAsSpan.Length; }
+
+            char[] buffer = ArrayPool<char>.Shared.Rent(length);
+            int    pos    = 0;
+            for (int k = start; k <= end; k++)
+            {
+                if (k > start) { buffer[pos++] = ' '; }
+                var s = tokens[k].ValueAsSpan;
+                s.CopyTo(buffer.AsSpan(pos));
+                pos += s.Length;
+            }
+
+            var uid = _captureResolver(buffer.AsSpan(0, length));
+            ArrayPool<char>.Shared.Return(buffer);
+            return uid;
         }
 
         private ReaderWriterLockSlim TrainLock = new ReaderWriterLockSlim();

--- a/Catalyst/src/Models/EntityRecognition/MphPerfectHash.cs
+++ b/Catalyst/src/Models/EntityRecognition/MphPerfectHash.cs
@@ -170,6 +170,13 @@ namespace Catalyst.Models
             uint f = (uint)CompactHash.Mix(key);
             return f == 0 ? 1u : f;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort Fingerprint16(ulong key)
+        {
+            ushort f = (ushort)CompactHash.Mix(key);
+            return f == 0 ? (ushort)1 : f;
+        }
     }
 
     /// <summary>
@@ -368,6 +375,71 @@ namespace Catalyst.Models
         public bool CanEnumerateKeys => false;
         public long EstimatedBytes   => _mph is null ? _fallback.EstimatedBytes
             : 24 + (long)_fp.Length * sizeof(uint) + _mph.DisplacementBytes + (_overflow is null ? 0 : 32L * _overflow.Count + 64);
+
+        public IEnumerable<ulong> Keys() => throw new NotSupportedException("A fingerprint-compressed spotter cannot enumerate its original keys.");
+    }
+
+    /// <summary>
+    /// Lossy perfect-hash membership set storing a 16-bit fingerprint per key (load factor ~1.0). ~2^-16
+    /// (~0.0015%) false-positive rate; never false negatives. The small overflow set keeps full keys, so
+    /// overflow members are exact. Intended for use behind an authoritative validator that can reject the
+    /// (rare) false positives - e.g. a graph-backed capture resolver - in exchange for ~3.5 B/key.
+    /// </summary>
+    internal sealed class MphFingerprint16Set64 : ICompactHashSet64
+    {
+        private readonly Mph                  _mph;
+        private readonly ushort[]             _fp;
+        private readonly HashSet<ulong>       _overflow;
+        private readonly bool                 _hasZero;
+        private readonly int                  _count;
+        private readonly FingerprintHashSet64 _fallback;
+        public bool Perfect       => _overflow is null;
+        public int  OverflowCount => _overflow?.Count ?? 0;
+
+        public MphFingerprint16Set64(ICollection<ulong> source)
+        {
+            _count = source.Count;
+            var pul = ArrayPool<ulong>.Shared;
+            ulong[] scratch = pul.Rent(_count == 0 ? 1 : _count);
+            try
+            {
+                int n = 0; bool hasZero = false;
+                foreach (var k in source) { if (k == 0) hasZero = true; else scratch[n++] = k; }
+                _hasZero = hasZero;
+                var mph = Mph.Build(scratch, n, out var ofIdx, out var ofCount);
+                if (mph is null) { _fallback = new FingerprintHashSet64(source); return; }
+                _mph = mph;
+                _fp  = new ushort[_mph.M];
+
+                var ofSet = ofCount > 0 ? new HashSet<int>(ofCount) : null;
+                for (int i = 0; i < ofCount; i++) { ofSet.Add(ofIdx[i]); }
+                for (int i = 0; i < n; i++)
+                {
+                    if (ofSet is object && ofSet.Contains(i)) { continue; }
+                    _fp[_mph.Slot(scratch[i])] = Mph.Fingerprint16(scratch[i]);
+                }
+                if (ofCount > 0)
+                {
+                    _overflow = new HashSet<ulong>(ofCount);
+                    for (int i = 0; i < ofCount; i++) { _overflow.Add(scratch[ofIdx[i]]); }
+                }
+            }
+            finally { pul.Return(scratch); }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Contains(ulong key)
+        {
+            if (_mph is null) { return _fallback.Contains(key); }
+            if (key == 0) { return _hasZero; }
+            if (_fp[_mph.Slot(key)] == Mph.Fingerprint16(key)) { return true; }
+            return _overflow is object && _overflow.Contains(key);
+        }
+
+        public int  Count            => _mph is null ? _fallback.Count : _count;
+        public bool CanEnumerateKeys => false;
+        public long EstimatedBytes   => _mph is null ? _fallback.EstimatedBytes
+            : 24 + (long)_fp.Length * sizeof(ushort) + _mph.DisplacementBytes + (_overflow is null ? 0 : 32L * _overflow.Count + 64);
 
         public IEnumerable<ulong> Keys() => throw new NotSupportedException("A fingerprint-compressed spotter cannot enumerate its original keys.");
     }

--- a/tests/Catalyst.Tests/MphPerfectHashTests.cs
+++ b/tests/Catalyst.Tests/MphPerfectHashTests.cs
@@ -135,6 +135,32 @@ namespace Catalyst.Tests
             Assert.False(map.CanEnumerateKeys);
         }
 
+        [Theory]
+        [InlineData(1000)]
+        [InlineData(100_000)]
+        public void MphFingerprint16Set_NoFalseNegatives_AndLowFalsePositiveRate(int count)
+        {
+            var keys    = RandomKeys(count, 91 + count, includeZero: true);
+            var present = new HashSet<ulong>(keys);
+            var set     = new MphFingerprint16Set64(present);
+
+            Assert.Equal(present.Count, set.Count);
+            Assert.False(set.CanEnumerateKeys);
+
+            // no false negatives - every member must be found
+            foreach (var k in keys) { Assert.True(set.Contains(k)); }
+
+            // false positives are allowed but should be ~2^-16; with 500k probes the expectation is ~7.6
+            var rng = new Random(123);
+            int fp = 0; const int trials = 500_000;
+            for (int i = 0; i < trials; i++)
+            {
+                ulong probe = (((ulong)(uint)rng.Next()) << 32) | (uint)rng.Next();
+                if (!present.Contains(probe) && set.Contains(probe)) { fp++; }
+            }
+            Assert.True(fp < 100, $"false-positive rate unexpectedly high: {fp}/{trials}");
+        }
+
         [Fact]
         public void Factory_BuildsPerfectHashStructures()
         {

--- a/tests/Catalyst.Tests/SpotterMemoryOptimizationTests.cs
+++ b/tests/Catalyst.Tests/SpotterMemoryOptimizationTests.cs
@@ -149,6 +149,66 @@ namespace Catalyst.Tests
         }
 
         [Fact]
+        public void LinkedSpotter_MembershipMode_FreezesReadOnlyAndReportsMemory()
+        {
+            var spotter = new LinkedSpotter(Language.English, 0, "", "Linked");
+            spotter.AddEntry("Curiosity", UID128.New());
+            spotter.AddEntry("New York", UID128.New());
+
+            // Providing a resolver switches the freeze to the probabilistic membership tables.
+            spotter.SetCaptureResolver(text => default);
+            spotter.OptimizeMemory();
+
+            Assert.True(spotter.IsMemoryOptimized);
+            Assert.True(spotter.OptimizedMemoryBytes > 0);
+
+            // Membership-only mode is lossy/read-only: mutating (which would need a lossless unfreeze) must throw.
+            Assert.Throws<System.InvalidOperationException>(() => spotter.AddEntry("Boston", UID128.New()));
+        }
+
+        [Fact]
+        public async Task LinkedSpotter_MembershipMode_ResolvesUidAndFiltersFalsePositives()
+        {
+            English.Register();
+
+            var curiosity = UID128.New();
+            var newYork   = UID128.New();
+
+            var spotter = new LinkedSpotter(Language.English, 0, "", "Linked");
+            spotter.AddEntry("Curiosity", curiosity);
+            spotter.AddEntry("New York", newYork);
+            spotter.AddEntry("Ghost", UID128.New()); // a member of the table that the resolver will reject
+
+            // The resolver stands in for the graph: it accepts only real entities and supplies their UID.
+            spotter.SetCaptureResolver(text =>
+            {
+                var s = text.ToString();
+                if (s == "Curiosity") { return curiosity; }
+                if (s == "New York") { return newYork; }
+                return default; // not in the graph -> drop (covers "Ghost" and any fingerprint false positive)
+            });
+
+            var nlp = await Pipeline.ForAsync(Language.English);
+            nlp.Add(spotter);
+
+            spotter.OptimizeMemory();
+            Assert.True(spotter.IsMemoryOptimized);
+
+            var doc = new Document("Curiosity works in New York with Ghost.", Language.English);
+            nlp.ProcessSingle(doc);
+
+            var values = EntityValues(doc);
+            Assert.Contains("Curiosity", values);
+            Assert.Contains("New York", values);
+            Assert.DoesNotContain("Ghost", values); // table-member, but the resolver rejected it
+
+            // the emitted UID is the one the resolver returned
+            var entities = doc.SelectMany(s => s.GetEntities()).ToArray();
+            Assert.Contains(entities, e => e.Value == "New York" && e.EntityType.TargetUID == newYork);
+            Assert.Contains(entities, e => e.Value == "Curiosity" && e.EntityType.TargetUID == curiosity);
+        }
+
+        [Fact]
         public async Task Spotter_CanMutateAfterFreezeInExactMode()
         {
             English.Register();


### PR DESCRIPTION
Follow-up to #140 / #141. When a `LinkedSpotter`'s captures can be validated against an authoritative source (the graph), false positives are acceptable as long as there are **no false negatives**. This adds an **opt-in** mode that exploits that for a large memory reduction.

## Mechanism
- **New `CaptureResolver` delegate** — `Func<ReadOnlySpan<char> matchedText, UID128>`. Calling `SetCaptureResolver(...)` before the model is frozen switches its frozen tables to a probabilistic membership representation. The resolver both **filters the (rare) false positives** and **supplies the authoritative UID**, so the 16-byte stored UIDs are dropped entirely.
- **New `MphFingerprint16Set64`** (`ICompactHashSet64`) — the #141 perfect hash + a **16-bit fingerprint**: ~3.5 B/key, ~2⁻¹⁶ (≈0.0015%) false-positive rate, and **never false negatives** (the small overflow set keeps full keys exactly). `CompactHash.BuildProbabilisticSet` builds it.
- **`Freeze()`** — with a resolver set, `Hashes` collapses to a membership set over its *keys* and each `MultiGramHashes` set becomes probabilistic; the model is then read-only (mutate / re-store throws, same contract as fingerprint mode).
- **Recognition** — the membership path mirrors the exact **longest-match** semantics, resolving each candidate through the resolver and keeping the longest *validated* match, so a probabilistic over-extension can never drop a real shorter match.

A bare perfect hash can't be used as a filter (it maps *every* input into range, so non-members would all "hit"); the 16-bit fingerprint is what makes it a filter, and the graph resolver mops up the residual ~0.0015%.

## Memory (per entry, for a `LinkedSpotter`)
- `Hashes` map → membership set: **~31 → ~3.5 B/key** (~9×; this is the dominant component).
- `MultiGramHashes`: **~11 → ~3.5 B/key** (~3×).

## Safety
- **Fully opt-in / no behavior change** when no resolver is set — recognition, storage and the exact/fingerprint paths are untouched.
- Membership-only mode is lossy/read-only (`Unfreeze`/`AddEntry`/`StoreAsync` throw a clear error), consistent with the existing fingerprint mode.
- The resolver returns the UID it resolved from the graph, so captures can never link to a "real-but-wrong" node (the failure mode that made `HasNode` on the spotter-returned UID unworkable for a probabilistic *map*).

## Tests
- `MphFingerprint16Set64` — no false negatives over 100k keys (incl. the overflow path), measured FP rate within ~2⁻¹⁶. **Runs/passes.**
- `LinkedSpotter` membership mode — read-only freeze + `OptimizedMemoryBytes`>0 (**runs/passes**); plus an end-to-end test that the resolver supplies the UID and rejects a table-member it doesn't recognize (needs the English model, so it can't execute in the CI sandbox — same constraint as the existing recognition tests — but compiles and is valid).

## Consumer note (Mosaik)
A separate Mosaik PR will supply the graph-backed resolver (`TryGetNode` + field-value match under the spotter's case rules + `_Alias` existence check) and a package bump. I'll flag any behavior-change risks there before wiring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAfiqhVByfgySyS9Ui3MGS)_