### PR TITLE
Add token length pre-filter optimization to entity spotters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Catalyst
+
+C# natural language processing library (tokenization, tagging, entity recognition, embeddings).
+
+## Build & test
+
+```bash
+dotnet build Catalyst/Catalyst.csproj -c Release
+dotnet test tests/Catalyst.Tests/Catalyst.Tests.csproj -c Release
+```
+
+## Git LFS required for tests (model files)
+
+The `.bin` / `.binz` model files under `Languages/` and `Languages.ForTest/` are stored
+with **Git LFS** (see `.gitattributes`). A plain clone that hasn't fetched LFS objects
+leaves these as small text *pointer* files instead of the real binaries.
+
+When that happens, tests that load a language model (anything going through
+`English.Register()` / `Pipeline.ForAsync(..., tagger: true)`) fail while deserializing,
+with an error like:
+
+```
+MessagePack.MessagePackSerializationException: Failed to deserialize
+Catalyst.Models.AveragePerceptronTaggerModel value.
+---- Unexpected msgpack code 118 (positive fixint) encountered.
+```
+
+`118` is `0x76` = `'v'`, the first byte of the LFS pointer text (`version https://git-lfs...`) —
+the deserializer is reading the pointer instead of the model.
+
+Fix by hydrating the LFS objects:
+
+```bash
+git lfs install --local
+git lfs pull            # or scope it, e.g. --include="Languages.ForTest/English.ForTests/Resources/*"
+```
+
+Fresh/ephemeral environments (e.g. Claude Code on the web) clone without LFS content unless the
+environment is set up to fetch it, so make sure LFS is configured there (or run `git lfs pull`
+once per session) before running model-dependent tests.

--- a/Catalyst/src/Models/EntityRecognition/LinkedSpotter.cs
+++ b/Catalyst/src/Models/EntityRecognition/LinkedSpotter.cs
@@ -21,6 +21,11 @@ namespace Catalyst.Models
         public HashSet<int> TokenizerExceptionsSet { get; set; } = new HashSet<int>();
         public bool IgnoreOnlyNumeric { get; set; }
         public bool IgnoreCase { get; set; }
+
+        /// <summary>Smallest character length among the individual tokens stored in the model, or 0 when the model is empty.</summary>
+        public int MinTokenLength { get; set; }
+        /// <summary>Largest character length among the individual tokens stored in the model, or 0 when the model is empty.</summary>
+        public int MaxTokenLength { get; set; }
     }
 
     public class LinkedSpotter : StorableObjectV2<LinkedSpotter, LinkedSpotterModel>, IEntityRecognizer, IProcess, IHasSimpleSpecialCases, ICanOptimizeMemory
@@ -167,6 +172,29 @@ namespace Catalyst.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool HashesTryGetValue(ulong hash, out UID128 uid) => _frozen ? _frozenHashes.TryGetValue(hash, out uid) : Data.Hashes.TryGetValue(hash, out uid);
 
+        // Widens the tracked [MinTokenLength, MaxTokenLength] window to cover a newly stored token length.
+        private void ObserveTokenLength(int length)
+        {
+            if (length <= 0) { return; }
+            if (Data.MaxTokenLength == 0) // model was empty until now
+            {
+                Data.MinTokenLength = length;
+                Data.MaxTokenLength = length;
+            }
+            else
+            {
+                if (length < Data.MinTokenLength) { Data.MinTokenLength = length; }
+                if (length > Data.MaxTokenLength) { Data.MaxTokenLength = length; }
+            }
+        }
+
+        // Cheap length pre-filter applied before hashing a token: a token whose length falls outside the window
+        // of every stored token can never match any stored hash, so we skip computing its hash entirely.
+        // A MaxTokenLength of 0 means the window is unknown (an empty model, or a model stored before this
+        // optimization existed), in which case filtering is disabled to preserve the exact previous behavior.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool CouldMatchLength(int length) => Data.MaxTokenLength == 0 || (length >= Data.MinTokenLength && length <= Data.MaxTokenLength);
+
         public void Process(IDocument document, CancellationToken cancellationToken = default)
         {
             RecognizeEntities(document);
@@ -247,6 +275,8 @@ namespace Catalyst.Models
             Data.Hashes                 = new Dictionary<ulong, UID128>();
             Data.MultiGramHashes        = new List<HashSet<ulong>>();
             Data.TokenizerExceptionsSet = new HashSet<int>();
+            Data.MinTokenLength         = 0;
+            Data.MaxTokenLength         = 0;
         }
 
         public bool RecognizeEntities(Span ispan, bool stopOnFirstFound = false)
@@ -262,6 +292,8 @@ namespace Catalyst.Models
                 var tk = tokens[i];
                 //if (tk.POS != PartOfSpeechEnum.NOUN && tk.POS != PartOfSpeechEnum.ADJ && tk.POS != PartOfSpeechEnum.PROPN) { continue; }
 
+                if (!CouldMatchLength(tk.Length)) { continue; } //Length pre-filter: skip hashing tokens that cannot match any stored entry
+
                 var tokenHash = Data.IgnoreCase ? IgnoreCaseHash64(tk.ValueAsSpan) : Hash64(tk.ValueAsSpan);
 
                 if (hasMultiGram && MultiGramContains(0, tokenHash))
@@ -276,6 +308,8 @@ namespace Catalyst.Models
                     {
                         var next = tokens[n + i];
                         someTokenHasReplacements |= (next.Replacement is object);
+
+                        if (!CouldMatchLength(next.Length)) { break; } //Out-of-range token cannot extend the multi-gram, so stop before hashing
 
                         var nextHash = Data.IgnoreCase ? IgnoreCaseHash64(next.ValueAsSpan) : Hash64(next.ValueAsSpan);
                         if (MultiGramContains(n, nextHash))
@@ -369,8 +403,9 @@ namespace Catalyst.Models
             {
                 var wordSpan = entrySpan.Slice(validCurrentPart.Start.Value, validCurrentPart.End.Value - validCurrentPart.Start.Value);
                 var hash = Data.IgnoreCase ? Spotter.IgnoreCaseHash64(wordSpan) : Spotter.Hash64(wordSpan);
-                
+
                 Data.Hashes[hash] = uid;
+                ObserveTokenLength(wordSpan.Length);
 
                 if (!wordSpan.IsAllLetterOrDigit())
                 {
@@ -393,6 +428,7 @@ namespace Catalyst.Models
                     var wordSpan = entrySpan.Slice(currentPart.Start.Value, currentPart.End.Value - currentPart.Start.Value);
 
                     var word_hash = Data.IgnoreCase ? Spotter.IgnoreCaseHash64(wordSpan) : Spotter.Hash64(wordSpan);
+                    ObserveTokenLength(wordSpan.Length);
                     if (n == 0) { combinedHash = word_hash; } else { combinedHash = Spotter.HashCombine64(combinedHash, word_hash); }
 
                     if (Data.MultiGramHashes.Count < n + 1)

--- a/Catalyst/src/Models/EntityRecognition/PatternSpotter.cs
+++ b/Catalyst/src/Models/EntityRecognition/PatternSpotter.cs
@@ -537,7 +537,7 @@ namespace Catalyst.Models
         /// <summary>Gets or sets the exact token value to match.</summary>
         [Key(8)] public string Token { get; set; }
         /// <summary>Gets or sets the set of token values to match.</summary>
-        [Key(9)] public string[] Set { get => set; set { set = value?.Distinct()?.ToArray(); _setHashes = set is object ? new HashSet<ulong>(set.Select(tk => CaseSensitive ? PatternUnitPrototype.Hash64(tk.AsSpan()) : PatternUnitPrototype.IgnoreCaseHash64(tk.AsSpan()))) : null; } }
+        [Key(9)] public string[] Set { get => set; set { set = value?.Distinct()?.ToArray(); RebuildSetHashes(); } }
         /// <summary>Gets or sets the entity type to match.</summary>
         [Key(10)] public string EntityType { get => entityType; set { entityType = value; _splitEntityType = entityType is object ? new HashSet<string>(entityType.Split(splitChar, StringSplitOptions.RemoveEmptyEntries)) : null; } }
 
@@ -567,6 +567,8 @@ namespace Catalyst.Models
         private HashSet<string> _splitEntityType;
         private HashSet<string> _splitShape;
         private HashSet<ulong> _setHashes;
+        private int _setMinLength;
+        private int _setMaxLength;
 
         private string suffix;
         private string prefix;
@@ -809,10 +811,39 @@ namespace Catalyst.Models
             return false;
         }
 
+        // Precomputes the set-membership hashes together with the [min, max] character-length window of the set
+        // entries. The length window is the source for the pre-filter in MatchSet - a token can only equal one of
+        // the set entries if its length matches one of them, so we can reject out-of-range tokens without hashing.
+        private void RebuildSetHashes()
+        {
+            if (set is null)
+            {
+                _setHashes    = null;
+                _setMinLength = 0;
+                _setMaxLength = 0;
+                return;
+            }
+
+            _setHashes = new HashSet<ulong>(set.Select(tk => CaseSensitive ? PatternUnitPrototype.Hash64(tk.AsSpan()) : PatternUnitPrototype.IgnoreCaseHash64(tk.AsSpan())));
+
+            int min = int.MaxValue, max = 0;
+            foreach (var tk in set)
+            {
+                int len = tk?.Length ?? 0;
+                if (len < min) { min = len; }
+                if (len > max) { max = len; }
+            }
+            _setMinLength = min;
+            _setMaxLength = max;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool MatchSet(ref Token token)
         {
-            return _setHashes is object && _setHashes.Contains(GetTokenHash(ref token));
+            if (_setHashes is null) { return false; }
+            int length = token.Length;
+            if (length < _setMinLength || length > _setMaxLength) { return false; } //Length pre-filter: a token outside the set's length window cannot be in the set, so skip hashing
+            return _setHashes.Contains(GetTokenHash(ref token));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Catalyst/src/Models/EntityRecognition/Spotter.cs
+++ b/Catalyst/src/Models/EntityRecognition/Spotter.cs
@@ -21,6 +21,11 @@ namespace Catalyst.Models
         public Dictionary<int, TokenizationException> TokenizerExceptions { get; set; } = new Dictionary<int, TokenizationException>();
         public bool IgnoreOnlyNumeric { get; set; }
         public bool IgnoreCase { get; set; }
+
+        /// <summary>Smallest character length among the individual tokens stored in the model, or 0 when the model is empty.</summary>
+        public int MinTokenLength { get; set; }
+        /// <summary>Largest character length among the individual tokens stored in the model, or 0 when the model is empty.</summary>
+        public int MaxTokenLength { get; set; }
     }
 
     public class Spotter : StorableObjectV2<Spotter, SpotterModel>, IEntityRecognizer, IProcess, IHasSpecialCases, ICanOptimizeMemory
@@ -175,6 +180,29 @@ namespace Catalyst.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool HashesContains(ulong hash) => _frozen ? _frozenHashes.Contains(hash) : Data.Hashes.Contains(hash);
 
+        // Widens the tracked [MinTokenLength, MaxTokenLength] window to cover a newly stored token length.
+        private void ObserveTokenLength(int length)
+        {
+            if (length <= 0) { return; }
+            if (Data.MaxTokenLength == 0) // model was empty until now
+            {
+                Data.MinTokenLength = length;
+                Data.MaxTokenLength = length;
+            }
+            else
+            {
+                if (length < Data.MinTokenLength) { Data.MinTokenLength = length; }
+                if (length > Data.MaxTokenLength) { Data.MaxTokenLength = length; }
+            }
+        }
+
+        // Cheap length pre-filter applied before hashing a token: a token whose length falls outside the window
+        // of every stored token can never match any stored hash, so we skip computing its hash entirely.
+        // A MaxTokenLength of 0 means the window is unknown (an empty model, or a model stored before this
+        // optimization existed), in which case filtering is disabled to preserve the exact previous behavior.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool CouldMatchLength(int length) => Data.MaxTokenLength == 0 || (length >= Data.MinTokenLength && length <= Data.MaxTokenLength);
+
         public void Process(IDocument document, CancellationToken cancellationToken = default)
         {
             RecognizeEntities(document);
@@ -260,6 +288,8 @@ namespace Catalyst.Models
             Data.Hashes              = new HashSet<ulong>();
             Data.MultiGramHashes     = new List<HashSet<ulong>>();
             Data.TokenizerExceptions = new Dictionary<int, TokenizationException>();
+            Data.MinTokenLength      = 0;
+            Data.MaxTokenLength      = 0;
         }
 
         public bool RecognizeEntities(Span ispan, bool stopOnFirstFound = false)
@@ -275,6 +305,8 @@ namespace Catalyst.Models
                 var tk = tokens[i];
                 //if (tk.POS != PartOfSpeechEnum.NOUN && tk.POS != PartOfSpeechEnum.ADJ && tk.POS != PartOfSpeechEnum.PROPN) { continue; }
 
+                if (!CouldMatchLength(tk.Length)) { continue; } //Length pre-filter: skip hashing tokens that cannot match any stored entry
+
                 var tokenHash = Data.IgnoreCase ? IgnoreCaseHash64(tk.ValueAsSpan) : Hash64(tk.ValueAsSpan);
 
                 if (hasMultiGram && MultiGramContains(0, tokenHash))
@@ -288,6 +320,8 @@ namespace Catalyst.Models
                     {
                         var next = tokens[n + i];
                         someTokenHasReplacements |= (next.Replacement is object);
+
+                        if (!CouldMatchLength(next.Length)) { break; } //Out-of-range token cannot extend the multi-gram, so stop before hashing
 
                         var nextHash = Data.IgnoreCase ? IgnoreCaseHash64(next.ValueAsSpan) : Hash64(next.ValueAsSpan);
                         if (MultiGramContains(n, nextHash))
@@ -488,6 +522,7 @@ namespace Catalyst.Models
                             Data.MultiGramHashes.Add(new HashSet<ulong>());
                         }
                         Data.MultiGramHashes[i].Add(hashes[i]);
+                        if (words.TryGetValue(hashes[i], out var word)) { ObserveTokenLength(word.Length); }
                     }
                 }
             }
@@ -536,6 +571,7 @@ namespace Catalyst.Models
             {
                 var hash = Data.IgnoreCase ? Spotter.IgnoreCaseHash64(words[0].AsSpan()) : Spotter.Hash64(words[0].AsSpan());
                 AddSingleTokenConcept(hash);
+                ObserveTokenLength(words[0].Length);
 
                 if (!words[0].AsSpan().IsAllLetterOrDigit())
                 {
@@ -549,6 +585,7 @@ namespace Catalyst.Models
             for (int n = 0; n < words.Length; n++)
             {
                 var word_hash = Data.IgnoreCase ? Spotter.IgnoreCaseHash64(words[n].AsSpan()) : Spotter.Hash64(words[n].AsSpan());
+                ObserveTokenLength(words[n].Length);
                 if (n == 0) { combinedHash = word_hash; } else { combinedHash = Spotter.HashCombine64(combinedHash, word_hash); }
                 if (Data.MultiGramHashes.Count < n + 1)
                 {

--- a/tests/Catalyst.Tests/SpotterLengthOptimizationTests.cs
+++ b/tests/Catalyst.Tests/SpotterLengthOptimizationTests.cs
@@ -1,0 +1,123 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Catalyst.Models;
+using Mosaik.Core;
+using UID;
+using Xunit;
+
+namespace Catalyst.Tests
+{
+    // Exercises the min/max token-length pre-filter that lets the spotters skip hashing a token whose length
+    // could not possibly match any stored entry. The tests assert that the optimization does not change any
+    // observable recognition result, including at the exact min/max boundaries and across a store/reload cycle.
+    public class SpotterLengthOptimizationTests
+    {
+        private static string[] EntityValues(IDocument doc) =>
+            doc.SelectMany(span => span.GetEntities()).Select(e => e.Value).OrderBy(v => v).ToArray();
+
+        [Fact]
+        public async Task Spotter_RecognizesEntriesAtLengthBoundaries()
+        {
+            English.Register();
+
+            var spotter = new Spotter(Language.English, 0, "", "Entity");
+            spotter.AddEntry("AI");         // shortest single token (length 2)
+            spotter.AddEntry("Curiosity");  // longest single token (length 9)
+            spotter.AddEntry("New York");   // multi-gram whose tokens sit inside the window
+
+            var nlp = await Pipeline.ForAsync(Language.English, tagger: false, sentenceDetector: false);
+            nlp.Add(spotter);
+
+            const string text = "AI at Curiosity is based near New York, not in X or Supercalifragilistic.";
+
+            var doc = new Document(text, Language.English);
+            nlp.ProcessSingle(doc);
+            var values = EntityValues(doc);
+
+            Assert.Contains("AI", values);          // exactly at the min length
+            Assert.Contains("Curiosity", values);   // exactly at the max length
+            Assert.Contains("New York", values);
+            Assert.DoesNotContain("X", values);      // below the min length - filtered, must not match
+            Assert.DoesNotContain("Supercalifragilistic", values); // above the max length - filtered, must not match
+        }
+
+        [Fact]
+        public async Task Spotter_RecognitionUnchangedAfterStoreAndReload()
+        {
+            English.Register();
+
+            var spotter = new Spotter(Language.English, 0, "", "Entity");
+            spotter.AddEntry("Curiosity");
+            spotter.AddEntry("San Francisco Bay");
+
+            using var ms = new MemoryStream();
+            await spotter.StoreAsync(ms);
+            ms.Position = 0;
+
+            var reloaded = new Spotter(Language.English, 0, "", "Entity");
+            await reloaded.LoadAsync(ms);
+            reloaded.TrimExcess();
+
+            var nlp = await Pipeline.ForAsync(Language.English, tagger: false, sentenceDetector: false);
+            nlp.Add(reloaded);
+
+            const string text = "Curiosity is near the San Francisco Bay area.";
+            var doc = new Document(text, Language.English);
+            nlp.ProcessSingle(doc);
+            var values = EntityValues(doc);
+
+            Assert.Contains("Curiosity", values);
+            Assert.Contains("San Francisco Bay", values);
+        }
+
+        [Fact]
+        public async Task LinkedSpotter_RecognizesEntriesAtLengthBoundaries()
+        {
+            English.Register();
+
+            var ai        = UID128.New();
+            var curiosity = UID128.New();
+            var newYork   = UID128.New();
+
+            var spotter = new LinkedSpotter(Language.English, 0, "", "Linked");
+            spotter.AddEntry("AI", ai);
+            spotter.AddEntry("Curiosity", curiosity);
+            spotter.AddEntry("New York", newYork);
+
+            var nlp = await Pipeline.ForAsync(Language.English, tagger: false, sentenceDetector: false);
+            nlp.Add(spotter);
+
+            const string text = "AI at Curiosity works in New York, not in X.";
+            var doc = new Document(text, Language.English);
+            nlp.ProcessSingle(doc);
+            var values = EntityValues(doc);
+
+            Assert.Contains("AI", values);
+            Assert.Contains("Curiosity", values);
+            Assert.Contains("New York", values);
+            Assert.DoesNotContain("X", values);
+        }
+
+        [Fact]
+        public async Task PatternSpotter_SetMatchRespectsLengthWindow()
+        {
+            English.Register();
+
+            var nlp = await Pipeline.ForAsync(Language.English, tagger: false, sentenceDetector: false);
+            var spotter = new PatternSpotter(Language.English, 0, "test", "CAP");
+            // Set entries all have length 3, so the length pre-filter admits only 3-char tokens for hashing.
+            spotter.NewPattern("Animals", mp => mp.Add(new PatternUnit(PatternUnitPrototype.Single().WithTokens(new[] { "cat", "dog" }, ignoreCase: true))));
+            nlp.Add(spotter);
+
+            var doc = new Document("Cat dog cats ox", Language.English);
+            nlp.ProcessSingle(doc);
+            var values = EntityValues(doc);
+
+            Assert.Contains("Cat", values);           // in set (case-insensitive)
+            Assert.Contains("dog", values);           // in set
+            Assert.DoesNotContain("cats", values);    // length 4, outside the set window
+            Assert.DoesNotContain("ox", values);      // length 2, outside the set window
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a length-based pre-filter optimization to the entity recognition spotters (`Spotter`, `LinkedSpotter`, and `PatternSpotter`) to skip hash computation for tokens that cannot possibly match any stored entries based on character length alone.

## Key Changes

- **Spotter & LinkedSpotter**: Track the minimum and maximum character lengths of stored tokens via new `MinTokenLength` and `MaxTokenLength` fields in their model data classes
  - Added `ObserveTokenLength()` method to update the length window when entries are added
  - Added `CouldMatchLength()` pre-filter method that rejects tokens outside the stored length range before hashing
  - Applied the pre-filter in `RecognizeEntities()` for both single-token and multi-gram matching paths
  - Reset length bounds when clearing the model

- **PatternSpotter**: Similar optimization for set-based pattern matching
  - Refactored set hash building into `RebuildSetHashes()` method that also computes the min/max length window
  - Applied length pre-filter in `MatchSet()` to skip hashing tokens outside the set's length range

- **Tests**: Added comprehensive test suite (`SpotterLengthOptimizationTests`) covering:
  - Recognition at exact length boundaries (min/max)
  - Correct filtering of out-of-range tokens
  - Behavior preservation across store/reload cycles
  - All three spotter types (Spotter, LinkedSpotter, PatternSpotter)

- **Documentation**: Added `CLAUDE.md` with build instructions and Git LFS setup guidance for model files

## Implementation Details

- The optimization is backward-compatible: models stored before this change have `MaxTokenLength = 0`, which disables filtering to preserve exact previous behavior
- The pre-filter uses `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for performance-critical paths
- Multi-gram matching breaks early when encountering an out-of-range token, avoiding unnecessary hash computations
- The length window is computed from actual stored token lengths, making it precise and requiring no configuration

https://claude.ai/code/session_014haxGXesFwgcQAGT2sHyQt